### PR TITLE
Use jenkins apt key id to avoid request

### DIFF
--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: jenkins-install | Install Jenkins pt. 1
-  apt_key: url=http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key
+  apt_key: url=http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key id=D50582E6
 
 - name: jenkins-install | Install Jenkins pt. 2
   apt_repository: repo='deb http://pkg.jenkins-ci.org/debian binary/' update_cache=yes


### PR DESCRIPTION
By adding the key id, we avoid requesting the key, if it is already installed.
