### PR TITLE
Add support for apache proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ jenkins_nginx_auth_users: []                # Add http auth users
                                             # jenkins_nginx_auth_users:
                                             #   - { name: team, password: secret }
 
+jenkins_apache_proxy: no                    # Enable apache proxy
+jenkins_apache_hostname: ""                 # Set jenkins host
+jenkins_apache_auth: no                     # Enable http auth
+jenkins_apache_auth_users: []               # Add http auth users
+                                            # jenkins_apache_auth_users:
+                                            #   - { name: team, password: secret }
+
+
 jenkins_apt_packages: []                    # Ensure the packages installed
 jenkins_plugins: []                         # Ensure the plugins is installed
 jenkins_jobs: []                            # Simple manage Jenkins jobs

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,13 @@ jenkins_nginx_auth_users: []                # Add http auth users
                                             # jenkins_nginx_auth_users:
                                             #   - { name: team, password: secret }
 
+jenkins_apache_proxy: no                     # Enable apache proxy
+jenkins_apache_hostname: ""                  # Set jenkins host
+jenkins_apache_auth: no                     # Enable http auth
+jenkins_apache_auth_users: []                # Add http auth users
+                                            # jenkins_apache_auth_users:
+                                            #   - { name: team, password: secret }
+
 jenkins_apt_packages: []                    # Ensure the packages installed
 jenkins_plugins: []                         # Ensure the plugins is installed
 jenkins_jobs: []                            # Simple manage Jenkins jobs

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,3 +9,6 @@
 
 - name: nginx reload
   service: name=nginx state=reloaded
+
+- name: apache restart
+  service: name=apache2 state=restarted

--- a/tasks/apache.yml
+++ b/tasks/apache.yml
@@ -1,0 +1,11 @@
+---
+
+- name: jenkins-apache | Encrypt http auth passwords
+  htpasswd: path={{jenkins_home}}/.htpasswd name={{item.name}} password={{item.password}}
+  with_items: jenkins_apache_auth_users
+  when: jenkins_apache_auth
+
+- name: jenkins-apache | Compile Apache configuration
+  template: src=apache.conf.j2 dest=/etc/apache2/sites-enabled/jenkins.conf
+  notify:
+    - apache restart

--- a/tasks/jenkins.yml
+++ b/tasks/jenkins.yml
@@ -22,3 +22,7 @@
 - include: nginx.yml
   when: jenkins_nginx_proxy
   tags: [jenkins, jenkins-nginx]
+
+- include: apache.yml
+  when: jenkins_apache_proxy
+  tags: [jenkins, jenkins-apache]

--- a/templates/apache.conf.j2
+++ b/templates/apache.conf.j2
@@ -1,0 +1,21 @@
+<VirtualHost *:80>
+  ServerName {{jenkins_apache_hostname}} 
+  ProxyPass         /  http://127.0.0.1:{{jenkins_http_port}}/ nocanon
+  ProxyPassReverse  /  http://127.0.0.1:{{jenkins_http_port}}/
+  ProxyRequests     Off
+  AllowEncodedSlashes NoDecode
+
+  {% if jenkins_apache_auth %}
+    <Location />
+      AuthType Basic
+      AuthName "CI Server"
+      AuthUserFile {{jenkins_home}}/.htpasswd
+      Require valid-user
+    </Location>
+  {% endif %}
+
+  <Proxy http://127.0.0.1:{{jenkins_http_port}}/*>
+    Order deny,allow
+    Allow from all
+  </Proxy>
+</VirtualHost>


### PR DESCRIPTION
Setup proxy for jenkins using apache. It also includes base http auth support.
