### PR TITLE
fix typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jenkins_http_port: 8000                     # Set jenkins port
 jenkins_ssh_key_file: ""                    # Set private ssh key for Jenkins user (path to key)
 jenkins_ssh_known_hosts: []                 # Set known hosts for ssh
 
-jenkins_proxy: ""                           # Enable jenkins proxy. Values are: nginx, apacha
+jenkins_proxy: ""                           # Enable jenkins proxy. Values are: nginx, apache
 jenkins_proxy_hostname: ""                  # Set proxy servername
 jenkins_proxy_port: 80                      # Set proxy port
 jenkins_proxy_auth: yes                     # Enable http auth

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ jenkins_http_port: 8000                     # Set jenkins port
 jenkins_ssh_key_file: ""                    # Set private ssh key for Jenkins user (path to key)
 jenkins_ssh_known_hosts: []                 # Set known hosts for ssh
 
-jenkins_proxy: ""                           # Enable jenkins proxy. Values are: nginx, apacha
+jenkins_proxy: ""                           # Enable jenkins proxy. Values are: nginx, apache
 jenkins_proxy_hostname: ""                  # Set proxy servername
 jenkins_proxy_port: 80                      # Set proxy port
 jenkins_proxy_auth: yes                     # Enable http auth


### PR DESCRIPTION
In tasks we are expecting `apache` instead of `apacha`
