### PR TITLE
Fix hardcoded refs to 127.0.0.1 when configuring a different bind address

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,7 +4,7 @@
   service: name=jenkins state=restarted
 
 - name: jenkins create jobs
-  shell: java -jar {{jenkins_home}}/jenkins-cli.jar -s http://127.0.0.1:{{jenkins_http_port}}/ {{item.action}}-job {{item.name}}
+  shell: java -jar {{jenkins_home}}/jenkins-cli.jar -s http://{{jenkins_http_host}}:{{jenkins_http_port}}/ {{item.action}}-job {{item.name}}
   with_items: jenkins_jobs
 
 - name: nginx reload

--- a/tasks/jobs.yml
+++ b/tasks/jobs.yml
@@ -1,5 +1,5 @@
 ---
 
 - name: jenkins-jobs | Manage jobs
-  shell: java -jar {{jenkins_home}}/jenkins-cli.jar -s http://127.0.0.1:{{jenkins_http_port}}{{ jenkins_prefix }}/ {{item.action}}-job {{item.name}}
+  shell: java -jar {{jenkins_home}}/jenkins-cli.jar -s http://{{jenkins_http_host}}:{{jenkins_http_port}}{{ jenkins_prefix }}/ {{item.action}}-job {{item.name}}
   with_items: jenkins_jobs

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -9,7 +9,7 @@
 - file: path={{jenkins_home}}/updates/default.json owner={{jenkins_user}} group={{jenkins_group}} mode=0755
 
 - name: jenkins-plugins | Install Jenkins plugins.
-  command: java -jar {{jenkins_home}}/jenkins-cli.jar -s http://127.0.0.1:{{jenkins_http_port}}/ install-plugin {{item}} creates={{jenkins_home}}/plugins/{{item}}.jpi
+  command: java -jar {{jenkins_home}}/jenkins-cli.jar -s http://{{jenkins_http_host}}:{{jenkins_http_port}}/ install-plugin {{item}} creates={{jenkins_home}}/plugins/{{item}}.jpi
   with_items: jenkins_plugins
   ignore_errors: yes
   notify: jenkins restart

--- a/templates/jenkins.j2
+++ b/templates/jenkins.j2
@@ -54,7 +54,7 @@ HTTP_HOST={{jenkins_http_host}}
 HTTP_PORT={{jenkins_http_port}}
 
 # Listen address for AJP connector
-AJP_HOST=127.0.0.1
+AJP_HOST={{jenkins_http_host}}
 
 #Custom prefix
 PREFIX={{jenkins_prefix}}


### PR DESCRIPTION
These would cause timeouts and fail if you bound to, say, an internal NIC's IP instead of using the local-only default intended for proxying.
