### PR TITLE
Update nginx.conf.j2

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -7,6 +7,7 @@ server {
     server_name       {{jenkins_proxy_hostname}};
     {% endif %}
     client_max_body_size 1024m;
+    ignore_invalid_headers off;
 
     location / {
         proxy_pass http://127.0.0.1:{{jenkins_http_port}};


### PR DESCRIPTION
If you enable "Prevent Cross Site Request Forgery exploits" in Jenkins, it starts sending `.crumb` header with csrf token.
However, by default Nginx accepts only alpha-numeric headers.
This change allowed Nginx to pass this header through.
Otherwise Jenkins will begin cursing with "403 No valid crumb included in request".
