### PR TITLE
Invoke jenkins-cli.jar as jenkins_user so that it's private key is used for authentication

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -10,6 +10,7 @@
 
 - name: jenkins-plugins | Install Jenkins plugins.
   command: java -jar {{jenkins_home}}/jenkins-cli.jar -s http://{{jenkins_http_host}}:{{jenkins_http_port}}{{jenkins_prefix}} install-plugin {{item}} creates={{jenkins_home}}/plugins/{{item}}.jpi
+  sudo_user: "{{ jenkins_user }}"
   with_items: jenkins_plugins
   ignore_errors: yes
   notify: jenkins restart


### PR DESCRIPTION
Otherwise it's only working with default (unsecured) Jenkins installations
