### PR TITLE
Add new variable 'jenkins_url'

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ jenkins_group: jenkins
 jenkins_configuration: /etc/default/jenkins
 jenkins_home: /var/lib/jenkins              # Jenkins home location
 jenkins_root: /usr/share/jenkins            # Location of jenkins arch indep files
+
 jenkins_http_host: 127.0.0.1                # Set HTTP host
 jenkins_http_port: 8000                     # Set HTTP port
+jenkins_url: http://{{jenkins_http_host}}:{{jenkins_http_port}}
 
 jenkins_ssh_key_file: ""                    # Set private ssh key for Jenkins user (path to local file)
 jenkins_ssh_fingerprints:                   # Set known hosts for ssh

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ jenkins_home: /var/lib/jenkins              # Jenkins home location
 jenkins_root: /usr/share/jenkins            # Location of jenkins arch indep files
 jenkins_http_host: 127.0.0.1                # Set HTTP host
 jenkins_http_port: 8000                     # Set HTTP port
+jenkins_url: http://{{ jenkins_http_host }}:{{ jenkins_http_port }}
 jenkins_maxopenfiles: 65535                 # Increase files limit
 
 jenkins_ssh_key_file: ""                    # Set private ssh key for Jenkins user (path to local file)

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -11,7 +11,7 @@
   with_items: jenkins_jobs_changed.results
 
 - name: jenkins reload configuration
-  command: java -jar {{jenkins_home}}/jenkins-cli.jar -s http://{{jenkins_http_host}}:{{jenkins_http_port}}{{jenkins_prefix}} reload-configuration
+  command: java -jar {{jenkins_home}}/jenkins-cli.jar -s {{jenkins_url}}{{jenkins_prefix}} reload-configuration
   sudo_user: "{{ jenkins_user }}"
 
 - name: nginx reload

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -16,7 +16,7 @@
   when: jenkins_service_configure.changed
 
 - name: Wait untils Jenkins web API is available
-  shell: curl --head --silent http://{{ jenkins_http_host }}:{{ jenkins_http_port }}{{ jenkins_prefix }}/cli/
+  shell: curl --head --silent {{ jenkins_url }}{{ jenkins_prefix }}/cli/
   delay: 10
   retries: 12
   until: result.stdout.find("200 OK") != -1
@@ -25,7 +25,7 @@
   when: jenkins_service_configure.changed
   
 - name: jenkins-configure | Copy jenkins-cli
-  get_url: url=http://{{jenkins_http_host}}:{{jenkins_http_port}}{{ jenkins_prefix }}/jnlpJars/jenkins-cli.jar dest={{jenkins_home}}/jenkins-cli.jar
+  get_url: url={{ jenkins_url }}{{ jenkins_prefix }}/jnlpJars/jenkins-cli.jar dest={{ jenkins_home }}/jenkins-cli.jar
   register: jenkins_cli
   until: "'OK' in jenkins_cli.msg or 'file already exists' in jenkins_cli.msg"
   sudo: yes  

--- a/tasks/jobs.yml
+++ b/tasks/jobs.yml
@@ -11,7 +11,7 @@
   register: jenkins_jobs_changed
 
 - name: jenkins-jobs | Manage jobs
-  shell: java -jar {{jenkins_home}}/jenkins-cli.jar -s http://{{jenkins_http_host}}:{{jenkins_http_port}}{{ jenkins_prefix }}/ {{item.action|default('enable')}}-job {{item.name}}
+  shell: java -jar {{jenkins_home}}/jenkins-cli.jar -s {{jenkins_url}}{{ jenkins_prefix }}/ {{item.action|default('enable')}}-job {{item.name}}
   sudo_user: "{{ jenkins_user }}"
   when: item.action is defined
   with_items: jenkins_jobs

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -9,7 +9,7 @@
 - file: path={{jenkins_home}}/updates/default.json owner={{jenkins_user}} group={{jenkins_group}} mode=0755
 
 - name: jenkins-plugins | Install Jenkins plugins.
-  command: java -jar {{jenkins_home}}/jenkins-cli.jar -s http://{{jenkins_http_host}}:{{jenkins_http_port}}{{jenkins_prefix}} install-plugin {{item}} creates={{jenkins_home}}/plugins/{{item}}.jpi
+  command: java -jar {{jenkins_home}}/jenkins-cli.jar -s {{jenkins_url}}{{jenkins_prefix}} install-plugin {{item}} creates={{jenkins_home}}/plugins/{{item}}.jpi
   sudo_user: "{{ jenkins_user }}"
   with_items: jenkins_plugins
   ignore_errors: yes

--- a/templates/jenkins_system_config.xml.j2
+++ b/templates/jenkins_system_config.xml.j2
@@ -3,5 +3,5 @@
   <adminAddress>{{jenkins_system_config.admin_email}}</adminAddress>
 {% if jenkins_proxy %}
   <jenkinsUrl>http://{{jenkins_proxy_hostname}}:{{jenkins_proxy_port}}/</jenkinsUrl>{% else %}
-  <jenkinsUrl>http://{{jenkins_http_host}}:{{jenkins_http_port}}/</jenkinsUrl>{% endif %}
+  <jenkinsUrl>{{jenkins_url}}/</jenkinsUrl>{% endif %}
 </jenkins.model.JenkinsLocationConfiguration>

--- a/templates/job.sh.j2
+++ b/templates/job.sh.j2
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 export JOB="$1"
-export CLI="java -jar {{jenkins_home}}/jenkins-cli.jar -s http://{{jenkins_http_host}}:{{jenkins_http_port}}"
+export CLI="java -jar {{jenkins_home}}/jenkins-cli.jar -s {{ jenkins_url }}"
 
 [ -z "$JOB" ] && exit 1
 


### PR DESCRIPTION
This PR adds a new variable `jenkins_url`.  By default `jenkins_url` is defined as `http://{{ jenkins_http_host }}:{{ jenkins_http_port }}`.  This variable is useful when using Jenkins behind an SSL proxy, where the Jenkins URL is something like `https://jenkins.mydomain.com`.  

The new variable is used throughout the code wherever `jenkins_http_host` and `jenkins_http_port` were formerly used together.  