### PR TITLE
don't use jenkins_url during configuration

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -11,7 +11,7 @@
   with_items: jenkins_jobs_changed.results
 
 - name: jenkins reload configuration
-  command: java -jar {{jenkins_home}}/jenkins-cli.jar -s {{jenkins_url}}{{jenkins_prefix}} reload-configuration
+  command: java -jar {{jenkins_home}}/jenkins-cli.jar -s http://{{ jenkins_http_host }}:{{ jenkins_http_port }}{{jenkins_prefix}} reload-configuration
   sudo_user: "{{ jenkins_user }}"
 
 - name: nginx reload

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -16,7 +16,7 @@
   when: jenkins_service_configure.changed
 
 - name: Wait untils Jenkins web API is available
-  shell: curl --head --silent {{ jenkins_url }}{{ jenkins_prefix }}/cli/
+  shell: curl --head --silent http://{{ jenkins_http_host }}:{{ jenkins_http_port }}{{ jenkins_prefix }}/cli/
   delay: 10
   retries: 12
   until: result.stdout.find("200 OK") != -1
@@ -25,7 +25,7 @@
   when: jenkins_service_configure.changed
   
 - name: jenkins-configure | Copy jenkins-cli
-  get_url: url={{ jenkins_url }}{{ jenkins_prefix }}/jnlpJars/jenkins-cli.jar dest={{ jenkins_home }}/jenkins-cli.jar
+  get_url: url=http://{{ jenkins_http_host }}:{{ jenkins_http_port }}{{ jenkins_prefix }}/jnlpJars/jenkins-cli.jar dest={{ jenkins_home }}/jenkins-cli.jar
   register: jenkins_cli
   until: "'OK' in jenkins_cli.msg or 'file already exists' in jenkins_cli.msg"
   sudo: yes  


### PR DESCRIPTION
The `jenkins_url` variable is useful for configuring Jenkins when it will be running behind a proxy such as nginx.  However the proxy server may not yet be running during Jenkins configuration.  Therefore we should use `http://{{ jenkins_http_host }}:{{ jenkins_http_port }}` for configuration tasks.  