### PR TITLE
Ensure more strictly that Jenkins is up

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,6 +4,28 @@
   service: name=jenkins state=restarted
   sudo: yes
   
+- name: jenkins restart
+  wait_for: host="{{ jenkins_http_host }}" port="{{ jenkins_http_port}}" timeout=30
+
+- name: jenkins restart
+  shell: curl --head --silent http://{{ jenkins_http_host }}:{{ jenkins_http_port }}{{ jenkins_prefix }}/cli/
+  delay: 10
+  retries: 12
+  until: result.stdout.find("200 OK") != -1
+  register: result
+  changed_when: False
+
+- name: jenkins update jobs
+  shell: curl --head --silent http://{{ jenkins_http_host }}:{{ jenkins_http_port }}{{ jenkins_prefix }}/cli/
+  delay: 10
+  retries: 12
+  until: result.stdout.find("200 OK") != -1
+  register: result
+  changed_when: False
+
+- name: jenkins update jobs
+  wait_for: host="{{ jenkins_http_host }}" port="{{ jenkins_http_port}}" timeout=30
+
 - name: jenkins update jobs
   command: "{{jenkins_home}}/jobs/job.sh {{item.item.name}}"
   sudo_user: "{{ jenkins_user }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -13,7 +13,6 @@
 - name: jenkins-configure | Ensure Jenkins restarted
   service: name=jenkins state=restarted
   sudo: yes  
-  when: jenkins_service_configure.changed
 
 - name: Wait untils Jenkins web API is available
   shell: curl --head --silent http://{{ jenkins_http_host }}:{{ jenkins_http_port }}{{ jenkins_prefix }}/cli/


### PR DESCRIPTION
We had problems that looked like a possible race condition
when adding more plugins with the current install. Restarting
jenkins seemed to take too much time. The plain wait_for for
the socket to open did not solve the whole issue, but then the
/cli/ URL was not responding.

The pull request content is not ideal by any means (the curl
check to see that Jenkins is fully started is triplicated),
but maybe you get the idea.