### PR TITLE
Allow job to skip git tagging

### DIFF
--- a/templates/job.xml.j2
+++ b/templates/job.xml.j2
@@ -35,7 +35,7 @@
     <excludedUsers></excludedUsers>
     <gitConfigName></gitConfigName>
     <gitConfigEmail></gitConfigEmail>
-    <skipTag>false</skipTag>
+    <skipTag>{{ job.skip_tag|default("false") }}</skipTag>
     <includedRegions></includedRegions>
     <scmName></scmName>
   </scm>


### PR DESCRIPTION
Many of us do not want to create a git tag per Jenkins build, 
so it's nice to be able to configure that by job.