### PR TITLE
moved run directory to jenkins user home

### DIFF
--- a/templates/jenkins.j2
+++ b/templates/jenkins.j2
@@ -27,7 +27,7 @@ JENKINS_WAR={{jenkins_war}}
 JENKINS_HOME={{jenkins_home}}
 
 # jenkins /run location
-JENKINS_RUN=/var/run/jenkins
+JENKINS_RUN={{jenkins_home}}/run
 
 # set this to false if you don't want Hudson to run by itself
 # in this set up, you are expected to provide a servlet container


### PR DESCRIPTION
the /var/run directory is linked to /run on many distributions which often is only a small tmpfs for runtime information about daemons and (in my case) is to small for the purposes of the Jenkins daemon.
My fix to put it under {{jenkins_home}}/run may not be the optimal solution in every case maybe this option should also be configurable.