### PR TITLE
fix out of space error on /var/run

### DIFF
--- a/templates/jenkins.j2
+++ b/templates/jenkins.j2
@@ -67,7 +67,7 @@ PREFIX={{jenkins_prefix}}
 # --argumentsRealm.passwd.$ADMIN_USER=[password]
 # --argumentsRealm.$ADMIN_USER=admin
 # --webroot=~/.jenkins/war
-JENKINS_ARGS="--webroot=$JENKINS_RUN/war --httpPort=$HTTP_PORT --ajp13Port=$AJP_PORT"
+JENKINS_ARGS="--webroot=/var/cache/$NAME/war --httpPort=$HTTP_PORT --ajp13Port=$AJP_PORT"
 JENKINS_ARGS="$JENKINS_ARGS --httpListenAddress=$HTTP_HOST --ajp13ListenAddress=$AJP_HOST"
 JENKINS_ARGS="$JENKINS_ARGS --preferredClassLoader=java.net.URLClassLoader"
 JENKINS_ARGS="$JENKINS_ARGS --prefix=$PREFIX"


### PR DESCRIPTION
When running the war file form /var/run will get an out of space error.
This error is described here with a potential workaround:
https://issues.jenkins-ci.org/browse/JENKINS-11366
it was fixed by
https://github.com/jenkinsci/packaging/commit/b98f3a38238b70d4ab2fd9183a7e8b6b9db39aff
and current implementation was applied to this commit:
https://github.com/jenkinsci/packaging/blob/93fb4c320a1204df638176c3c2a88109fd1b27d9/deb/build/debian/jenkins.default#L75

/var/cache/jenkins will also be cleared on `apt-get purge jenkins`