### PR TITLE
Add jenkins_cli_extra_opts variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ jenkins_root: /usr/share/jenkins            # Location of jenkins arch indep fil
 jenkins_http_host: 127.0.0.1                # Set HTTP host
 jenkins_http_port: 8000                     # Set HTTP port
 jenkins_url: http://{{jenkins_http_host}}:{{jenkins_http_port}}
+jenkins_cli_extra_opts: ""                  # Extra options for jenkins-cli.jar
 
 jenkins_ssh_key_file: ""                    # Set private ssh key for Jenkins user (path to local file)
 jenkins_ssh_fingerprints:                   # Set known hosts for ssh

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ jenkins_http_host: 127.0.0.1                # Set HTTP host
 jenkins_http_port: 8000                     # Set HTTP port
 jenkins_url: http://{{ jenkins_http_host }}:{{ jenkins_http_port }}
 jenkins_maxopenfiles: 65535                 # Increase files limit
+jenkins_cli_extra_opts: ""                  # Extra options for jenkins-cli.jar
 
 jenkins_ssh_key_file: ""                    # Set private ssh key for Jenkins user (path to local file)
 jenkins_ssh_fingerprints:                   # Set known hosts for ssh

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -33,7 +33,7 @@
   with_items: jenkins_jobs_changed.results
 
 - name: jenkins reload configuration
-  command: java -jar {{jenkins_home}}/jenkins-cli.jar -s http://{{ jenkins_http_host }}:{{ jenkins_http_port }}{{jenkins_prefix}} reload-configuration
+  command: java -jar {{jenkins_home}}/jenkins-cli.jar {{jenkins_cli_extra_opts}} -s http://{{ jenkins_http_host }}:{{ jenkins_http_port }}{{jenkins_prefix}} reload-configuration
   sudo_user: "{{ jenkins_user }}"
 
 - name: nginx reload

--- a/tasks/jobs.yml
+++ b/tasks/jobs.yml
@@ -11,7 +11,7 @@
   register: jenkins_jobs_changed
 
 - name: jenkins-jobs | Manage jobs
-  shell: java -jar {{jenkins_home}}/jenkins-cli.jar -s {{jenkins_url}}{{ jenkins_prefix }}/ {{item.action|default('enable')}}-job {{item.name}}
+  shell: java -jar {{jenkins_home}}/jenkins-cli.jar {{jenkins_cli_extra_opts}} -s {{jenkins_url}}{{ jenkins_prefix }}/ {{item.action|default('enable')}}-job {{item.name}}
   sudo_user: "{{ jenkins_user }}"
   when: item.action is defined
   with_items: jenkins_jobs

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -9,7 +9,7 @@
 - file: path={{jenkins_home}}/updates/default.json owner={{jenkins_user}} group={{jenkins_group}} mode=0755
 
 - name: jenkins-plugins | Install Jenkins plugins.
-  command: java -jar {{jenkins_home}}/jenkins-cli.jar -s {{jenkins_url}}{{jenkins_prefix}} install-plugin {{item}} creates={{jenkins_home}}/plugins/{{item}}.jpi
+  command: java -jar {{jenkins_home}}/jenkins-cli.jar {{jenkins_cli_extra_opts}} -s {{jenkins_url}}{{jenkins_prefix}} install-plugin {{item}} creates={{jenkins_home}}/plugins/{{item}}.jpi
   sudo_user: "{{ jenkins_user }}"
   with_items: jenkins_plugins
   ignore_errors: yes

--- a/templates/job.sh.j2
+++ b/templates/job.sh.j2
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 export JOB="$1"
-export CLI="java -jar {{jenkins_home}}/jenkins-cli.jar -s {{ jenkins_url }}"
+export CLI="java -jar {{jenkins_home}}/jenkins-cli.jar {{jenkins_cli_extra_opts}} -s {{ jenkins_url }}"
 
 [ -z "$JOB" ] && exit 1
 


### PR DESCRIPTION
In some cases, one may need to use an extra CLI option, in particular,
`-noKeyAuth`, or perhaps the `-i ssh_key` option. Adding this variable,
which defaults to the empty string, one can add CLI options on the
ansible-playbook command line, for example.

A particular situation is when running the CLI within Ansible as the
Jenkins user - is there really a point in using SSH credentials when
you are already the Jenkins user?