### PR TITLE
Adding Debian Wheezy

### DIFF
--- a/vars/Debian-wheezy.yml
+++ b/vars/Debian-wheezy.yml
@@ -1,0 +1,9 @@
+---
+apache_server_root: /etc/apache2
+apache_listen_port: "{{ jenkins_proxy_port }}"
+
+apache_ports_configuration_items:
+  - {
+    regexp: "^Listen ",
+    line: "Listen {{ apache_listen_port }}"
+  }


### PR DESCRIPTION
It fix this issue : 
TASK: [Stouts.jenkins | Include OS-specific variables.] *********************** 
fatal: [10.1.0.134] => input file not found at /etc/ansible/roles/Stouts.jenkins/vars/Debian-wheezy.yml or /home/admin/ansible/Debian-wheezy.yml

