### PR TITLE
Adding SSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ jenkins_ssh_fingerprints:                   # Set known hosts for ssh
 jenkins_proxy: ""                           # Enable jenkins proxy. Values are: nginx, apache
 jenkins_proxy_hostname: "{{inventory_hostname}}" # Set proxy servername
 jenkins_proxy_port: 80                      # Set proxy port
+jenkins_proxy_ssl: false                    # Enable SSL
+jenkins_proxy_ssl_certificate: /etc/nginx/ssl/certificate.crt # Path to certificate
+jenkins_proxy_ssl_key: /etc/nginx/ssl/certificate.key         # Path to key
 jenkins_proxy_auth: no                      # Enable http auth
 jenkins_proxy_auth_users: []                # Add http auth users
                                             # jenkins_proxy_auth_users:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,12 +20,15 @@ jenkins_ssh_fingerprints:                   # Set known hosts for ssh
   - "github.com,204.232.175.90 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="
 
 jenkins_proxy: ""                           # Enable jenkins proxy. Values are: nginx, apache
-jenkins_proxy_hostname: "{{inventory_hostname}}" # Set proxy servername
-jenkins_proxy_port: 80                      # Set proxy port
-jenkins_proxy_auth: no                      # Enable http auth
-jenkins_proxy_auth_users: []                # Add http auth users
-                                            # jenkins_proxy_auth_users:
-                                            #   - { name: team, password: secret }
+jenkins_proxy_hostname: "{{inventory_hostname}}"              # Set proxy servername
+jenkins_proxy_port: 80                                        # Set proxy port
+jenkins_proxy_ssl: false                                      # Enable SSL
+jenkins_proxy_ssl_certificate: /etc/nginx/ssl/certificate.crt # Path to certificate
+jenkins_proxy_ssl_key: /etc/nginx/ssl/certificate.key         # Path to key
+jenkins_proxy_auth: no                                        # Enable http auth
+jenkins_proxy_auth_users: []                                  # Add http auth users
+                                                              # jenkins_proxy_auth_users:
+                                                              #   - { name: team, password: secret }
 
 #latest
 #jenkins_apt_key: "http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key"

--- a/templates/jenkins_system_config.xml.j2
+++ b/templates/jenkins_system_config.xml.j2
@@ -2,6 +2,6 @@
 <jenkins.model.JenkinsLocationConfiguration>
   <adminAddress>{{jenkins_system_config.admin_email}}</adminAddress>
 {% if jenkins_proxy %}
-  <jenkinsUrl>http://{{jenkins_proxy_hostname}}:{{jenkins_proxy_port}}/</jenkinsUrl>{% else %}
+  <jenkinsUrl>{% if jenkins_proxy_ssl %}https{% else %}http{% endif %}://{{jenkins_proxy_hostname}}:{{jenkins_proxy_port}}/</jenkinsUrl>{% else %}
   <jenkinsUrl>{{jenkins_url}}/</jenkinsUrl>{% endif %}
 </jenkins.model.JenkinsLocationConfiguration>

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -9,6 +9,12 @@ server {
     client_max_body_size 8m;
     ignore_invalid_headers off;
 
+{% if jenkins_proxy_ssl %}
+    ssl on;
+    ssl_certificate {{ jenkins_proxy_ssl_certificate }};
+    ssl_certificate_key {{ jenkins_proxy_ssl_key }};
+{% endif %}
+
     location / {
         proxy_pass http://127.0.0.1:{{jenkins_http_port}};
 {% if jenkins_proxy_hostname %}


### PR DESCRIPTION
This PR add support for SSL on the proxy

I tested it and it works as expected. As the vhost works, it's up to the admin to create the nginx directory and upload the certs (I did it in a pre_tasks)