### PR TITLE
[FEATURE] Allow listening on different address than http_host

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ jenkins_configuration: /etc/default/jenkins
 jenkins_home: /var/lib/jenkins              # Jenkins home location
 jenkins_root: /usr/share/jenkins            # Location of jenkins arch indep files
 
+jenkins_listen_address: 0.0.0.0             # The address Jenkins will listen on
 jenkins_http_host: 127.0.0.1                # Set HTTP host
 jenkins_http_port: 8000                     # Set HTTP port
 jenkins_url: http://{{jenkins_http_host}}:{{jenkins_http_port}}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ jenkins_group: jenkins
 jenkins_configuration: /etc/default/jenkins
 jenkins_home: /var/lib/jenkins              # Jenkins home location
 jenkins_root: /usr/share/jenkins            # Location of jenkins arch indep files
+jenkins_listen_address: 127.0.0.1           # The address jenkins listens on
 jenkins_http_host: 127.0.0.1                # Set HTTP host
 jenkins_http_port: 8000                     # Set HTTP port
 jenkins_url: http://{{ jenkins_http_host }}:{{ jenkins_http_port }}

--- a/templates/jenkins.j2
+++ b/templates/jenkins.j2
@@ -48,7 +48,7 @@ MAXOPENFILES={{ jenkins_maxopenfiles }}
 AJP_PORT=-1
 
 # Listen address for HTTP connector
-HTTP_HOST={{jenkins_http_host}}
+HTTP_HOST={{jenkins_listen_address}}
 
 # port for HTTP connector (default 8080; disable with -1)
 HTTP_PORT={{jenkins_http_port}}


### PR DESCRIPTION
To directly expose Jenkins, e.g. within an intranet, it must listen on a different address than 127.0.0.1. Therefore, a new variable `jenkins_listen_address` is added that is used for setting up the server instead of the old `jenkins_http_host`.