### PR TITLE
[BUGFIX] Enforce become when managing jobs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ jenkins_enabled: yes                        # The role is enabled
 jenkins_name: jenkins
 jenkins_user: jenkins
 jenkins_group: jenkins
+jenkins_become_method: su
 jenkins_configuration: /etc/default/jenkins
 jenkins_home: /var/lib/jenkins              # Jenkins home location
 jenkins_root: /usr/share/jenkins            # Location of jenkins arch indep files

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ jenkins_enabled: yes                        # The role is enabled
 jenkins_name: jenkins
 jenkins_user: jenkins
 jenkins_group: jenkins
-jenkins_become_method: su
+jenkins_become_method: sudo
 jenkins_configuration: /etc/default/jenkins
 jenkins_home: /var/lib/jenkins              # Jenkins home location
 jenkins_root: /usr/share/jenkins            # Location of jenkins arch indep files

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -18,12 +18,16 @@
 - name: jenkins update jobs
   command: "{{jenkins_home}}/jobs/job.sh {{item.item.name}}"
   become_user: "{{ jenkins_user }}"
+  become: true
+  become_method: '{{ jenkins_become_method }}'
   when: item.changed
   with_items: "{{jenkins_jobs_changed.results}}"
 
 - name: jenkins reload configuration
   command: java -jar {{jenkins_home}}/jenkins-cli.jar {{jenkins_cli_extra_opts}} -s http://{{ jenkins_http_host }}:{{ jenkins_http_port }}{{jenkins_prefix}} reload-configuration
   become_user: "{{ jenkins_user }}"
+  become: true
+  become_method: '{{ jenkins_become_method }}'
 
 - name: nginx reload
   service: name=nginx state=reloaded

--- a/tasks/jobs.yml
+++ b/tasks/jobs.yml
@@ -16,5 +16,7 @@
 - name: jenkins-jobs | Manage jobs
   shell: java -jar {{jenkins_home}}/jenkins-cli.jar {{jenkins_cli_extra_opts}} -s {{jenkins_url}}{{ jenkins_prefix }}/ {{item.action|default('enable')}}-job {{item.name}}
   become_user: "{{ jenkins_user }}"
+  become: true
+  become_method: '{{ jenkins_become_method }}'
   when: item.action is defined
   with_items: "{{jenkins_jobs}}"

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -11,6 +11,8 @@
 - name: jenkins-plugins | Install Jenkins plugins.
   command: java -jar {{jenkins_home}}/jenkins-cli.jar {{jenkins_cli_extra_opts}} -s {{jenkins_url}}{{jenkins_prefix}} install-plugin {{item}} creates={{jenkins_home}}/plugins/{{item}}.jpi
   become_user: "{{ jenkins_user }}"
+  become: true
+  become_method: '{{ jenkins_become_method }}'
   with_items: "{{jenkins_plugins}}"
   ignore_errors: yes
   notify: 


### PR DESCRIPTION
Managing the jobs does not work e.g. when running Ansible as root, as become will not be used by default then.