### PR TITLE
Fix <jenkinsUrl> configuration

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -16,6 +16,7 @@ Contributors:
 * Keith Bussell (https://github.com/kbussell)
 * Kirill Klenov (http://klen.github.io/)
 * Marvin Reimer (https://github.com/therealmarv)
+* Mickaël Tricot (https://github.com/mickaeltr)
 * Sylvain Veyrié (https://github.com/turb)
 * Thomas B Homburg (https://github.com/homburg)
 * Timo Rantalaiho (https://github.com/timorantalaiho)

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,10 +5,10 @@
   become: yes
   
 - name: jenkins check web ready
-  wait_for: host="{{ jenkins_http_host }}" port="{{ jenkins_http_port}}" timeout=30
+  wait_for: host="{{ jenkins_http_host }}" port="{{ jenkins_http_port }}" timeout=30
 
 - name: jenkins check cli ready
-  shell: curl --head --silent http://{{ jenkins_http_host }}:{{ jenkins_http_port }}{{ jenkins_prefix }}/cli/
+  shell: curl --head --silent {{ jenkins_url }}/cli/
   delay: 10
   retries: 12
   until: result.stdout.find("200 OK") != -1
@@ -16,15 +16,15 @@
   changed_when: False
 
 - name: jenkins update jobs
-  command: "{{jenkins_home}}/jobs/job.sh {{item.item.name}}"
+  command: "{{ jenkins_home }}/jobs/job.sh {{ item.item.name }}"
   become_user: "{{ jenkins_user }}"
   become: true
   become_method: '{{ jenkins_become_method }}'
   when: item.changed
-  with_items: "{{jenkins_jobs_changed.results}}"
+  with_items: "{{ jenkins_jobs_changed.results }}"
 
 - name: jenkins reload configuration
-  command: java -jar {{jenkins_home}}/jenkins-cli.jar {{jenkins_cli_extra_opts}} -s http://{{ jenkins_http_host }}:{{ jenkins_http_port }}{{jenkins_prefix}} reload-configuration
+  command: java -jar {{ jenkins_home }}/jenkins-cli.jar {{ jenkins_cli_extra_opts }} -s {{ jenkins_url }} reload-configuration
   become_user: "{{ jenkins_user }}"
   become: true
   become_method: '{{ jenkins_become_method }}'

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -2,7 +2,7 @@
 
 - name: jenkins-configure | Configure Jenkins Service
   template:
-    dest: "{{jenkins_configuration}}"
+    dest: "{{ jenkins_configuration }}"
     src: jenkins.j2
   register: jenkins_service_configure
 
@@ -28,7 +28,7 @@
   when: not jenkins_service_configure.changed
 
 - name: Wait untils Jenkins web API is available
-  shell: curl --head --silent http://{{ jenkins_http_host }}:{{ jenkins_http_port }}{{ jenkins_prefix }}/cli/
+  shell: curl --head --silent {{ jenkins_url }}/cli/
   delay: 10
   retries: 12
   until: result.stdout.find("200 OK") != -1
@@ -37,14 +37,14 @@
   when: jenkins_service_configure.changed
 
 - name: jenkins-configure | Copy jenkins-cli
-  get_url: url=http://{{ jenkins_http_host }}:{{ jenkins_http_port }}{{ jenkins_prefix }}/jnlpJars/jenkins-cli.jar dest={{ jenkins_home }}/jenkins-cli.jar
+  get_url: url={{ jenkins_url }}/jnlpJars/jenkins-cli.jar dest={{ jenkins_home }}/jenkins-cli.jar
   register: jenkins_cli
   until: "'OK' in jenkins_cli.msg or 'file already exists' in jenkins_cli.msg"
   retries: 10
   delay: 10
 
 - name: jenkins-configure | Configure Jenkins System
-  template: src=jenkins_system_config.xml.j2 dest={{jenkins_home}}/jenkins.model.JenkinsLocationConfiguration.xml owner=jenkins group=jenkins force=yes
+  template: src=jenkins_system_config.xml.j2 dest={{ jenkins_home }}/jenkins.model.JenkinsLocationConfiguration.xml owner=jenkins group=jenkins force=yes
   notify: jenkins reload configuration
 
 - name: Configure log rotation

--- a/templates/jenkins_system_config.xml.j2
+++ b/templates/jenkins_system_config.xml.j2
@@ -1,7 +1,21 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <jenkins.model.JenkinsLocationConfiguration>
-  <adminAddress>{{jenkins_system_config.admin_email}}</adminAddress>
-{% if jenkins_proxy %}
-  <jenkinsUrl>{% if jenkins_proxy_ssl %}https{% else %}http{% endif %}://{{jenkins_proxy_hostname}}:{{jenkins_proxy_port}}/</jenkinsUrl>{% else %}
-  <jenkinsUrl>{{jenkins_url}}</jenkinsUrl>{% endif %}
+  <adminAddress>{{ jenkins_system_config.admin_email }}</adminAddress>
+  {% if jenkins_proxy %}
+    {% if jenkins_proxy_ssl %}
+      {% if jenkins_proxy_port == 443 %}
+        <jenkinsUrl>https://{{ jenkins_proxy_hostname }}{{ jenkins_prefix }}/</jenkinsUrl>
+      {% else %}
+        <jenkinsUrl>https://{{ jenkins_proxy_hostname }}:{{ jenkins_proxy_port }}{{ jenkins_prefix }}/</jenkinsUrl>
+      {% endif %}
+    {% else %}
+      {% if jenkins_proxy_port == 80 %}
+        <jenkinsUrl>http://{{ jenkins_proxy_hostname }}{{ jenkins_prefix }}/</jenkinsUrl>
+      {% else %}
+        <jenkinsUrl>http://{{ jenkins_proxy_hostname }}:{{ jenkins_proxy_port }}{{ jenkins_prefix }}/</jenkinsUrl>
+      {% endif %}
+    {% endif %}
+  {% else %}
+    <jenkinsUrl>{{ jenkins_url }}/</jenkinsUrl>
+  {% endif %}
 </jenkins.model.JenkinsLocationConfiguration>


### PR DESCRIPTION
Hello,

I think the jenkinsUrl:

- Must end with slash
- Must use the jenkins_prefix (also when proxyfied)
- Should not specify standard ports (80 for HTTP and 443 for HTTPS)

Cheers