### PR TITLE
Fix Unrecognized option error when booting

### DIFF
--- a/templates/jenkins.j2
+++ b/templates/jenkins.j2
@@ -69,5 +69,4 @@ PREFIX={{jenkins_prefix}}
 # --webroot=~/.jenkins/war
 JENKINS_ARGS="--webroot=/var/cache/$NAME/war --httpPort=$HTTP_PORT --ajp13Port=$AJP_PORT"
 JENKINS_ARGS="$JENKINS_ARGS --httpListenAddress=$HTTP_HOST --ajp13ListenAddress=$AJP_HOST"
-JENKINS_ARGS="$JENKINS_ARGS --preferredClassLoader=java.net.URLClassLoader"
 JENKINS_ARGS="$JENKINS_ARGS --prefix=$PREFIX"


### PR DESCRIPTION
When upgrading to Jenkins 2.7.1 the following error occurred:
```
INFO: JVM is terminating. Shutting down Winstone
Running from: /usr/share/jenkins/jenkins.war
Exception in thread "main" java.lang.reflect.InvocationTargetException
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at Main._main(Main.java:246)
        at Main.main(Main.java:91)
Caused by: java.lang.IllegalArgumentException: Unrecognized option: --preferredClassLoader=java.net.URLClassLoader
        at winstone.cmdline.CmdLineParser.parse(CmdLineParser.java:53)
        at winstone.Launcher.getArgsFromCommandLine(Launcher.java:359)
        at winstone.Launcher.main(Launcher.java:332)
        ... 6 more
```

Removing the `preferredClassLoader` option fixes it.