### PR TITLE
Make jenkins apt packages configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,6 +48,7 @@ jenkins_apt_key: http://pkg.jenkins-ci.org/debian-stable/jenkins-ci.org.key
 jenkins_apt_key_id: D50582E6
 jenkins_apt_repository: deb http://pkg.jenkins-ci.org/debian-stable binary/
 
+jenkins_apt_core_packages: [curl, jenkins]  # Ensure jenkins is installed
 jenkins_apt_packages: []                    # Ensure the packages installed
 jenkins_plugins: []                         # Ensure the plugins is installed
 jenkins_jobs: []                            # Simple manage Jenkins jobs

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -13,7 +13,7 @@
 - name: jenkins-install | Install jenkins
   apt:
     name: "{{item}}"
-  with_items: [curl, jenkins]
+  with_items: "{{jenkins_apt_core_packages}}"
 
 - name: jenkins-install | Install additional deb packages
   apt:


### PR DESCRIPTION
I implemented this to maintain backwards compatibility and allow installing a specific version of jenkins from the apt repository